### PR TITLE
add quotation marks to prevent ffmpeg crashing with some file names

### DIFF
--- a/whisper_s2t/audio.py
+++ b/whisper_s2t/audio.py
@@ -20,7 +20,7 @@ with tempfile.TemporaryDirectory() as tmpdir:
     if ret_code != 0:
         print(f"Seems 'ffmpeg' is not installed. Please install ffmpeg before using this package!")
     else:
-        ret_code = os.system(f'ffmpeg -hide_banner -loglevel panic -i {silent_file} -threads 1 -acodec pcm_s16le -ac 1 -af aresample=resampler={RESAMPLING_ENGINE} -ar 1600 {tmpdir}/tmp.wav -y')
+        ret_code = os.system(f'ffmpeg -hide_banner -loglevel panic -i "{silent_file}" -threads 1 -acodec pcm_s16le -ac 1 -af aresample=resampler={RESAMPLING_ENGINE} -ar 1600 "{tmpdir}/tmp.wav" -y')
 
         if ret_code != 0:
             print(f"'ffmpeg' is not built with soxr resampler, using 'swr' resampler. This may degrade performance.")
@@ -38,7 +38,7 @@ def load_audio(input_file, sr=16000, return_duration=False):
     except:
         with tempfile.TemporaryDirectory() as tmpdir:
             wav_file = f"{tmpdir}/tmp.wav"
-            ret_code = os.system(f'ffmpeg -hide_banner -loglevel panic -i {input_file} -threads 1 -acodec pcm_s16le -ac 1 -af aresample=resampler={RESAMPLING_ENGINE} -ar {sr} {wav_file} -y')
+            ret_code = os.system(f'ffmpeg -hide_banner -loglevel panic -i "{input_file}" -threads 1 -acodec pcm_s16le -ac 1 -af aresample=resampler={RESAMPLING_ENGINE} -ar {sr} "{wav_file}" -y')
             if ret_code != 0: raise RuntimeError("ffmpeg failed to resample the input audio file, make sure ffmpeg is compiled properly!")
         
             with wave.open(wav_file, 'rb') as wf:

--- a/whisper_s2t/backends/tensorrt/engine_builder/__init__.py
+++ b/whisper_s2t/backends/tensorrt/engine_builder/__init__.py
@@ -96,7 +96,7 @@ def build_trt_engine(model_name='large-v2', args=None, force=False, log_level='e
     if force:
         console.print(f"'force' flag is 'True'. Removing previous build.")
         with RunningStatus("Cleaning", console=console):
-            os.system(f"rm -rf {args.output_dir}")
+            os.system(f"rm -rf '{args.output_dir}'")
         
     if not os.path.exists(args.output_dir):
         os.makedirs(args.output_dir)
@@ -117,12 +117,12 @@ def build_trt_engine(model_name='large-v2', args=None, force=False, log_level='e
                 
         if _failed_export:
             console.print(f"Export directory exists but seems like a failed export, regenerating the engine files.")
-            os.system(f"rm -rf {args.output_dir}")
+            os.system(f"rm -rf '{args.output_dir}'")
             os.makedirs(args.output_dir)
         else:
             return args.output_dir
     
-    os.system(f"cp {tokenizer_path} {args.output_dir}/tokenizer.json")
+    os.system(f"cp '{tokenizer_path}' '{args.output_dir}/tokenizer.json'")
     save_trt_build_configs(args)
 
     with RunningStatus("Exporting Model To TensorRT Engine (3-6 mins)", console=console):


### PR DESCRIPTION
when using file names that contain spaces or brackets this error occurs
```/bin/bash: -c: line 1: syntax error near unexpected token `('
/bin/bash: -c: line 1: `ffmpeg -hide_banner -loglevel panic -i /content/20200128-Pieter Wuille (part 1 of 2) - Episode 1.mp3 -threads 1 -acodec pcm_s16le -ac 1 -af aresample=resampler=soxr -ar 16000 /tmp/tmps2xtcop7/tmp.wav -y'```

adding quotation helps