### PR TITLE
Replace `multiprocessing.dummy.Pool()` with `concurrent.futures.ThreadPoolExecutor()` so whisper_s2t instance can run separately with `multiprocessing.Process()`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 tqdm==4.66.2
 rich==13.7.0
-torch==2.1.2+cu121
+torch==2.1.2
 numpy==1.26.4
 platformdirs==4.2.0
 ctranslate2==4.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 tqdm==4.66.2
 rich==13.7.0
-torch==2.1.2
+torch>=2.1.2
 numpy==1.26.4
 platformdirs==4.2.0
 ctranslate2==4.0.0

--- a/whisper_s2t/backends/__init__.py
+++ b/whisper_s2t/backends/__init__.py
@@ -153,32 +153,46 @@ class WhisperModel(ABC):
             
             pbar.update(pbar.total-pbar_pos)
         
-        return responses
+        return responses        
 
     @torch.no_grad()
-    def transcribe_with_vad(self, audio_files, lang_codes=None, tasks=None, initial_prompts=None, batch_size=8):
-
+    def transcribe_with_vad(self, audio_files, lang_codes=None, tasks=None, initial_prompts=None, batch_size=8, progress_bar=True):
         lang_codes = fix_batch_param(lang_codes, 'en', len(audio_files))
         tasks = fix_batch_param(tasks, 'transcribe', len(audio_files))
         initial_prompts = fix_batch_param(initial_prompts, None, len(audio_files))
             
         responses = [[] for _ in audio_files]
         
-        pbar_pos = 0
-        with tqdm(total=len(audio_files)*100, desc=f"Transcribing") as pbar:
-            for signals, prompts, seq_len, seg_metadata, pbar_update in self.data_loader(audio_files, lang_codes, tasks, initial_prompts, batch_size=batch_size):
+        if progress_bar:
+            pbar_pos = 0
+            with tqdm(total=len(audio_files)*100, desc=f"Transcribing") as pbar:
+                for signals, prompts, seq_len, seg_metadata, pbar_update in self.data_loader(audio_files, lang_codes, tasks, initial_prompts, batch_size=batch_size):
+                    mels, seq_len = self.preprocessor(signals, seq_len)
+                    res = self.generate_segment_batched(mels.to(self.device), prompts, seq_len, seg_metadata)
+
+                    for res_idx, _seg_metadata in enumerate(seg_metadata):
+                        responses[_seg_metadata['file_id']].append({
+                            **res[res_idx],
+                            'start_time': round(_seg_metadata['start_time'], 3),
+                            'end_time': round(_seg_metadata['end_time'], 3)
+                        })
+                    
+                    if (pbar_pos) <= pbar.total:
+                        pbar_pos += pbar_update
+                        pbar.update(pbar_update)
+                
+                pbar.update(pbar.total-pbar_pos)
+        else:
+            for signals, prompts, seq_len, seg_metadata, _ in self.data_loader(audio_files, lang_codes, tasks, initial_prompts, batch_size=batch_size):
                 mels, seq_len = self.preprocessor(signals, seq_len)
                 res = self.generate_segment_batched(mels.to(self.device), prompts, seq_len, seg_metadata)
 
                 for res_idx, _seg_metadata in enumerate(seg_metadata):
-                    responses[_seg_metadata['file_id']].append({**res[res_idx],
-                                                                'start_time': round(_seg_metadata['start_time'], 3),
-                                                                'end_time': round(_seg_metadata['end_time'], 3)})
-                
-                if (pbar_pos) <= pbar.total:
-                    pbar_pos += pbar_update
-                    pbar.update(pbar_update)
-            
-            pbar.update(pbar.total-pbar_pos)
+                    responses[_seg_metadata['file_id']].append({
+                        **res[res_idx],
+                        'start_time': round(_seg_metadata['start_time'], 3), 
+                        'end_time': round(_seg_metadata['end_time'], 3)
+                    })
         
         return responses
+    


### PR DESCRIPTION
I tried loading whisper model and running transcription in a separate multiprocessing.Process(), but failed. The process just froze unresponsive when loading audio to memory with multiprocessing.dummy.Pool(). Replaced with a safer concurrent.futures.ThreadPoolExecutor() and it works now!